### PR TITLE
Update to 1.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This mod provides a Prometheus exporter for Minecraft. It exports metrics
 related to the Minecraft server and the JVM for consumption by the open-source
 systems monitoring toolkit, [Prometheus](https://prometheus.io/). The mod is
 intended for server-side use, and does not need to be installed client-side.
-This is currently made for Minecraft 1.14.4 with Forge 28.1.0.
+This is currently made for Minecraft 1.15.2 with Forge 31.2.0.
 
 
 Installation

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ ext {
 	modTrackerUrl = 'https://github.com/cpburnz/minecraft-prometheus-exporter/issues'
 	modUrl = 'https://github.com/cpburnz/minecraft-prometheus-exporter'
 
-	forgeMinVersion = '28'
-	minecraftMinVersion = '1.14.4'
+	forgeMinVersion = '31'
+	minecraftMinVersion = '1.15.2'
 }
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
@@ -64,7 +64,7 @@ minecraft {
 	// stable_#			Stables are built at the discretion of the MCP team.
 	// Use non-default mappings at your own risk. they may not always work.
 	// Simply re-run your setup task after changing the mappings to update your workspace.
-	mappings channel: 'snapshot', version: '20190719-1.14.3'
+	mappings channel: 'snapshot', version: '20200514-1.15.1'
 	// makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
 	// accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -137,12 +137,12 @@ dependencies {
 	// 'net.minecraft' it is assumed that the dep is a ForgeGradle 'patcher'
 	// dependency. And it's patches will be applied. The userdev artifact is a
 	// special name and will get all sorts of transformations applied to it.
-	minecraft 'net.minecraftforge:forge:1.14.4-28.1.0'
+	minecraft 'net.minecraftforge:forge:1.15.2-31.2.0'
 
 	// Prometheus dependencies.
-	compileAndShadow group: 'io.prometheus', name: 'simpleclient', version: '0.8.0'
-	compileAndShadow group: 'io.prometheus', name: 'simpleclient_httpserver', version: '0.8.0'
-	compileAndShadow group: 'io.prometheus', name: 'simpleclient_hotspot', version: '0.8.0'
+	compileAndShadow group: 'io.prometheus', name: 'simpleclient', version: '0.9.0'
+	compileAndShadow group: 'io.prometheus', name: 'simpleclient_httpserver', version: '0.9.0'
+	compileAndShadow group: 'io.prometheus', name: 'simpleclient_hotspot', version: '0.9.0'
 }
 
 // Expand variables in resource files.


### PR DESCRIPTION
I did a quick check and there seem to be no issues so far with updating to 1.15.2. While I was at it I also pulled up the prometheus exporter library version.